### PR TITLE
ONEUP-6319: remove terraform folder

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ runs:
       if: steps.infrastructure-changes.outputs.found == 'true'
       working-directory: ${{ inputs.module-path }}
       run: |
-        rm -rf .terraform.lock.hcl .terraform/terraform.tfstate || true
+        rm -rf .terraform.lock.hcl .terraform || true
         terraform init
         terraform validate
         terraform plan -var 'environment=production' -var 'revision=${{ inputs.docker-image-tag }}' -out tfplan


### PR DESCRIPTION
When we update ecs_service_fargate stack, we have a problem of executing stack because state is getting corrupted and we need to delete the entire ".terraform" folder.